### PR TITLE
Make eslint rules consistent within Normandy repos.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,25 +1,29 @@
 {
+    "extends": "eslint:recommended",
     "parser": "babel-eslint",
     "plugins": ["babel"],
     "rules": {
-        "strict": 0,
-        "indent": [2, 4],
-        "quotes": [2, "single"],
-        "linebreak-style": [2, "unix"],
+        "consistent-return": 2,
+        "eqeqeq": 2,
         "semi": [2, "always"],
-        "no-console": 0,
-        "babel/generator-star-spacing": 1,
-        "babel/new-cap": 1,
+
         "babel/array-bracket-spacing": 1,
+        "babel/arrow-parens": [1, "as-needed"],
+        "babel/new-cap": 1,
+        "babel/no-await-in-loop": 1,
         "babel/object-curly-spacing": 1,
-        "babel/object-shorthand": 0,
-        "babel/arrow-parens": 1,
-        "babel/no-await-in-loop": 1
+        "comma-dangle": [1, "always-multiline"],
+        "indent": [1, 4, {"SwitchCase": 1}],
+        "linebreak-style": [1, "unix"],
+        "no-unused-vars": [1],
+        "quotes": [1, "single", "avoid-escape"],
+
+        "no-console": 0,
+        "strict": 0
     },
     "env": {
         "es6": true,
         "node": true,
         "browser": true
-    },
-    "extends": "eslint:recommended"
+    }
 }

--- a/bin/upload.js
+++ b/bin/upload.js
@@ -27,7 +27,7 @@ if (argv._.length > 0) {
 }
 
 // Validate that the actions we want to upload have been built.
-actions = actions.filter((action) => {
+actions = actions.filter(action => {
     try {
         fs.accessSync(action.buildPath, fs.R_OK);
         return true;
@@ -52,13 +52,13 @@ for (let action of actions) {
     api.getAction(action.name).then(() => {
         api.updateAction(action.name, action).then(() =>{
             console.log(`Updated action ${action.name} successfully.`);
-        }).catch((err) => {
+        }).catch(err => {
             console.error(`Failed to update action ${action.name}: ${err}`);
         });
     }).catch(() => {
         api.createAction(action).then(() => {
             console.log(`Create action ${action.name} successfully.`);
-        }).catch((err) => {
+        }).catch(err => {
             console.error(`Failed to create action ${action.name}: ${err}`);
         });
     });

--- a/lib/api.js
+++ b/lib/api.js
@@ -30,10 +30,10 @@ export class NormandyApi {
             headers: {
                 'Authorization': `Token ${this.token}`,
                 'Accept': 'application/json',
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
             },
             body: body ? JSON.stringify(body) : '',
-            agent: new Agent({rejectUnauthorized: this.verify})
+            agent: new Agent({rejectUnauthorized: this.verify}),
         };
 
         return fetch(url, options);
@@ -52,7 +52,7 @@ export class NormandyApi {
         let response = await this.fetch('/action/', 'POST', {
             name: action.name,
             implementation: action.implementation,
-            arguments_schema: action.schema
+            arguments_schema: action.schema,
         });
 
         if (!response.ok) {
@@ -67,7 +67,7 @@ export class NormandyApi {
     async updateAction(name, action) {
         let response = await this.fetch(`/action/${name}/`, 'PATCH', {
             implementation: action.implementation,
-            arguments_schema: action.schema
+            arguments_schema: action.schema,
         });
 
         if (!response.ok) {


### PR DESCRIPTION
With these changes, the eslint configs for normandy-actions and normandy-addon are very similar, except for some environment specific changes, and 4 space indents here and 2 space indents there.

A lot of things moved around, for a reason. When organizing the file, I followed these rules
- Rules that when broken cause the program to behave differently are errors (level 2)
- Rules that when broken only cause the program to be harder to read or other wise don't affect the current behavior are warnings (level 1)
- Errors, warnings, and ignores are grouped together
- Each group is sorted mechanically

I also fixed the code so it matches these eslint rules.
