### PR TITLE
Fix bug 1266264: Annotate post-survey URL with more data.

### DIFF
--- a/actions/show-heartbeat/index.js
+++ b/actions/show-heartbeat/index.js
@@ -167,26 +167,27 @@ export default class ShowHeartbeatAction extends Action {
     }
 
     async annotatePostAnswerUrl(url) {
-        let args = [
-            ['source', 'heartbeat'],
-            ['surveyversion', VERSION],
-            ['updateChannel', this.client.channel],
-            ['fxVersion', this.client.version],
-        ];
+        let args = {
+            source: 'heartbeat',
+            surveyversion: VERSION,
+            updateChannel: this.client.channel,
+            fxVersion: this.client.version,
+            isDefaultBrowser: this.client.isDefaultBrowser ? 1 : 0,
+            searchEngine: this.client.searchEngine,
+            syncSetup: this.client.syncSetup ? 1 : 0,
+        };
 
         // Append testing parameter if in testing mode.
         if (this.normandy.testing) {
-            args.push(['testing', 1]);
+            args.testing = 1;
         }
 
-        let params = args.map(([a, b]) => `${a}=${b}`).join('&');
-        if (url.indexOf('?') !== -1) {
-            url += '&' + params;
-        } else {
-            url += '?' + params;
+        let annotatedUrl = new URL(url);
+        for (let key in args) {
+            annotatedUrl.searchParams.set(key, args[key]);
         }
 
-        return url;
+        return annotatedUrl.href;
     }
 
     /**

--- a/test/show-heartbeat.js
+++ b/test/show-heartbeat.js
@@ -122,12 +122,20 @@ describe('ShowHeartbeatAction', function() {
 
         this.normandy.mock.client.version = '42.0.1';
         this.normandy.mock.client.channel = 'nightly';
+        this.normandy.mock.client.isDefaultBrowser = true;
+        this.normandy.mock.client.searchEngine = 'shady-tims';
+        this.normandy.mock.client.syncSetup = true;
 
         await action.execute();
-        expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            postAnswerUrl: (url + '?source=heartbeat&surveyversion=52' +
-                            '&updateChannel=nightly&fxVersion=42.0.1'),
-        }));
+        let postAnswerUrl = this.normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+        let params = new URL(postAnswerUrl).searchParams;
+        expect(params.get('source')).toEqual('heartbeat');
+        expect(params.get('surveyversion')).toEqual('52');
+        expect(params.get('updateChannel')).toEqual('nightly');
+        expect(params.get('fxVersion')).toEqual('42.0.1');
+        expect(params.get('isDefaultBrowser')).toEqual('1');
+        expect(params.get('searchEngine')).toEqual('shady-tims');
+        expect(params.get('syncSetup')).toEqual('1');
     });
 
     it('should annotate the post-answer URL if it has an existing query string', async function() {
@@ -140,10 +148,10 @@ describe('ShowHeartbeatAction', function() {
         this.normandy.mock.client.channel = 'nightly';
 
         await action.execute();
-        expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            postAnswerUrl: (url + '&source=heartbeat&surveyversion=52' +
-                            '&updateChannel=nightly&fxVersion=42.0.1'),
-        }));
+        let postAnswerUrl = this.normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+        let params = new URL(postAnswerUrl).searchParams;
+        expect(params.get('foo')).toEqual('bar');
+        expect(params.get('source')).toEqual('heartbeat');
     });
 
     it('should annotate the post-answer URL with a testing param in testing mode', async function() {
@@ -153,14 +161,11 @@ describe('ShowHeartbeatAction', function() {
         let action = new ShowHeartbeatAction(this.normandy, recipe);
 
         this.normandy.testing = true;
-        this.normandy.mock.client.version = '42.0.1';
-        this.normandy.mock.client.channel = 'nightly';
 
         await action.execute();
-        expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            postAnswerUrl: (url + '?source=heartbeat&surveyversion=52' +
-                            '&updateChannel=nightly&fxVersion=42.0.1&testing=1'),
-        }));
+        let postAnswerUrl = this.normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+        let params = new URL(postAnswerUrl).searchParams;
+        expect(params.get('testing')).toEqual('1');
     });
 
     it('should pass some extra telemetry arguments to showHeartbeat', async function() {


### PR DESCRIPTION
Adds the extra data we weren't yet using from the [client](http://normandy.readthedocs.io/projects/actions/en/latest/driver.html#client). Also switches to using the `URL` constructor, now that our tests are running in Firefox.

@brittanystoroz r?
